### PR TITLE
envファイルがrailsに読み込まれていない問題を解決

### DIFF
--- a/.github/workflows/ci-backend-frontend.yml
+++ b/.github/workflows/ci-backend-frontend.yml
@@ -60,7 +60,7 @@ jobs:
         env:
             DB_USERNAME: ${{ secrets.DB_USERNAME }}
             DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-            DB_HOST: db
+            DB_HOST: localhost
             DB_PORT: ${{ secrets.DB_PORT }}
             POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
         run: bin/rspec

--- a/.github/workflows/ci-backend-frontend.yml
+++ b/.github/workflows/ci-backend-frontend.yml
@@ -38,10 +38,14 @@ jobs:
         env:
           DB_USERNAME: ${{ secrets.DB_USERNAME }}
           DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-          DB_HOST: db
+          DB_HOST: localhost
           DB_PORT: ${{ secrets.DB_PORT }}
           POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
         run: |
+          until pg_isready -h localhost -p $DB_PORT -U $DB_USERNAME; do
+              echo "Waiting for Postgres..."
+              sleep 1
+          done
           bundle exec rails db:create
           bundle exec rails db:schema:load
         working-directory: ./backend

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,6 @@
 FROM ruby:3.2.2
 WORKDIR /app
+RUN apt-get update && apt-get install -y postgresql-client
 COPY Gemfile* ./
 RUN bundle install
 COPY . .

--- a/backend/config/application.rb
+++ b/backend/config/application.rb
@@ -1,7 +1,6 @@
 require_relative "boot"
 require "rails/all"
-require 'dotenv'
-Dotenv.load('../../.env') if defined?(Dotenv)
+require 'dotenv/load'
 
 Bundler.require(*Rails.groups)
 

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -51,7 +51,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_26_150101) do
   create_table "visits", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "shop_id", null: false
-    t.date "visit_date", null: false
+    t.date "visit_date"
     t.text "comment"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -60,5 +60,4 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_26_150101) do
   end
 
   add_foreign_key "visits", "shops"
-  add_foreign_key "visits", "users"
 end


### PR DESCRIPTION
close #112 

## 原因
DATABASE_URLという余計な環境変数が設定されていた。