### PR TITLE
テンプレートリテラルを正しく使うためにバッククォートを使用

### DIFF
--- a/frontend/app/components/CurrentUserFetch.tsx
+++ b/frontend/app/components/CurrentUserFetch.tsx
@@ -12,7 +12,7 @@ const CurrentUserFetch = () => {
     }
 
     if (localStorage.getItem('access-token')) {
-      const url = '${process.env.NEXT_PUBLIC_API_BASE_URL}/current/user';
+      const url = `${process.env.NEXT_PUBLIC_API_BASE_URL}/current/user`;
       axios
         .get(url, {
           headers: {

--- a/frontend/app/password_reset/page.tsx
+++ b/frontend/app/password_reset/page.tsx
@@ -10,7 +10,7 @@ export default function PasswordResetPage() {
 
   const handlePasswordReset = async () => {
     try {
-      await axios.post('${process.env.NEXT_PUBLIC_API_BASE_URL}/users/password', {
+      await axios.post(`${process.env.NEXT_PUBLIC_API_BASE_URL}/users/password`, {
         user: { email },
       });
       setMessage('パスワードリセットメールを送信しました。');


### PR DESCRIPTION
学習メモ

'${process.env.NEXT_PUBLIC_API_BASE_URL}/current/user' の形式では、テンプレートリテラルが文字列として認識されてしまう。