### PR TITLE
Google Search Console用のメタタグを追加

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -11,6 +11,9 @@ export const metadata: Metadata = {
   title: 'セコマレコード',
   description:
     'セコマレコードは、「すべてのセイコーマートの店舗に行きたい」という想いから作られた、無料のセイコーマート訪問記録管理サービスです。会員登録せずに、セコマの店舗検索システムとして使用することもできます。セイコーマート非公式。',
+  verification: {
+  google: process.env.NEXT_PUBLIC_GOOGLE_SEARCH_CONSOLE_CONTENT,
+  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
close #52 

## 参考記事
https://gedem-blog.vercel.app/blog/vercel-nextjs-google-search-console/

## 備考
環境変数として設定し、Vercelで登録済み。
.envには記載していない。