### PR TITLE
店舗一覧ページで全ての店舗データが表示されるようにする

### DIFF
--- a/frontend/app/shop/page.tsx
+++ b/frontend/app/shop/page.tsx
@@ -27,7 +27,7 @@ export default function ShopListPage() {
 
     const fetchShops = async () => {
       try {
-        const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/shops/by_sub_area?sub_area=${subArea}`);
+        const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/shops/by_sub_area?sub_area=${subArea}&page=1&per_page=100`);
         if (!response.ok) throw new Error("Failed to fetch");
         const data = await response.json();
 


### PR DESCRIPTION
close #136 

per_page を100件まで取得するように変更。
100件以上データのあるセグメントは存在しないため、100件と指定した。